### PR TITLE
Modernize to Go 1.26 with modules, slog, context, and CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Build and Release Tagged Versions
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    name: Build and Release with GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,3 @@
-
-tnc-server-darwin-amd64
-
 tnc-server
-
-tnc-server-linux-amd64
-
-tnc-server-linux-arm7
-
-tnc-server-linux-armv6.tar.gz
-
-tnc-server-win32.exe
-
-tnc-server-win64.exe
+dist/
+scratch/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,72 @@
+version: 2
+
+project_name: tnc-server
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: tnc-server
+    main: .
+    binary: tnc-server
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - 386
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: arm64
+      - goos: darwin
+        goarch: 386
+      - goos: darwin
+        goarch: arm
+
+archives:
+  - id: tnc-server
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- if eq .Os "darwin" }}macOS{{ else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: 'checksums.txt'
+
+release:
+  draft: false
+  replace_existing_draft: true
+  replace_existing_artifacts: true
+  target_commitish: '{{ .Commit }}'
+  prerelease: auto
+  mode: replace
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/chrissnell/tnc-server
+
+go 1.26.1
+
+require go.bug.st/serial v1.6.4
+
+require (
+	github.com/creack/goselect v0.1.2 // indirect
+	golang.org/x/sys v0.19.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/creack/goselect v0.1.2 h1:2DNy14+JPjRBgPzAd1thbQp4BSIihxcBf0IXhQXDRa0=
+github.com/creack/goselect v0.1.2/go.mod h1:a/NhLweNvqIYMuxcMOuWY516Cimucms3DglDzQP3hKY=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+go.bug.st/serial v1.6.4 h1:7FmqNPgVp3pu2Jz5PoPtbZ9jJO5gnEnZIvnI1lzve8A=
+go.bug.st/serial v1.6.4/go.mod h1:nofMJxTeNVny/m6+KaafC6vJGj3miwQZ6vW4BZUGJPI=
+golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
+golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tnc-server.go
+++ b/tnc-server.go
@@ -1,234 +1,203 @@
-// tnc-server
-// A serial/TCP bridge for connecting multiple read/write clients to an AX.25/KISS TNC device.
-// Written in the Go programming language
-// (c) 2014, Christopher Snell
-
+// tnc-server bridges a KISS TNC serial device to multiple TCP clients,
+// allowing several applications to share a single packet radio TNC.
 package main
 
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
-	"github.com/tarm/goserial"
-	"github.com/tv42/topic"
-	"io"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
+	"sync"
+
+	"go.bug.st/serial"
 )
 
-var (
-	listen *string
-	debug  *bool
+const (
+	minKISSFrameSize = 15   // smallest KISS packet we expect to see
+	kissDelimiter    = 0xc0 // KISS frame boundary marker
 )
 
-// The smallest KISS packet that we can ever expect to see.
-const reasonableSize = 15
+// broadcaster distributes frames from one producer to many consumers.
+type broadcaster struct {
+	mu        sync.RWMutex
+	consumers map[chan []byte]struct{}
+}
 
-// This function sets up our TCP listener and our serial port ReadWriteCloser
-// and handles incoming connections.
-func newSerialListener(serialport io.ReadWriteCloser) {
-
-	// We're going to use Topic to handle the one -> many distribution
-	// of our serial->net traffic
-	top := topic.New()
-	defer close(top.Broadcast)
-
-	// We use a channel as a FIFO buffer to handle the many -> one
-	// writes from our net->serial traffic
-	msg := make(chan []byte, 15)
-
-	l, err := net.Listen("tcp", *listen)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer l.Close()
-
-	log.Printf("Listening for connections on %v\n", *listen)
-
-	// Launch a broadcaster in a goroutine that reads off the serial port and sends to Topic
-	go serialReaderBroadcaster(top, serialport)
-
-	// Launch a writer in a goroutine to receive our incoming writes and write them to serial
-	go serialWriter(serialport, msg)
-
-	for {
-		// Wait for a connection.
-		conn, err := l.Accept()
-		log.Printf("Answered incoming client connection from %v\n", conn.RemoteAddr())
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		// Set up a consumer channel for this new connection.  All reads off the
-		// serial port will be sent over this channel
-		consumer := make(chan interface{}, 1)
-		top.Register(consumer)
-
-		// Start a consumer goroutine to take the serial data off the consumer
-		// channel and send it to this network connection
-		go serialReaderConsumer(consumer, conn, top)
-
-		// Start a writer in a goroutine to read off the network and send all messages
-		// to the message buffer
-		go serialWriterConnection(conn, msg)
+func newBroadcaster() *broadcaster {
+	return &broadcaster{
+		consumers: make(map[chan []byte]struct{}),
 	}
 }
 
-// This function reads off the serial port and sends what it gets to Topic
-func serialReaderBroadcaster(top *topic.Topic, serialport io.ReadWriteCloser) {
-	var err error
-
-	// Wrap the goserial's ReadWriteCloser with a bufio.Reader so we can do fancy stuffs.
-	sr := bufio.NewReader(serialport)
-
-	for {
-
-		frame := []byte{}
-
-		for len(frame) <= reasonableSize {
-			// Read forward until we encounter 0xc0 and return this data including the 0xc0.
-			frame, err = sr.ReadBytes(byte(0xc0))
-			if err != nil {
-				log.Printf("Error reading bytes from serial: %v\n", err)
-			}
-		}
-
-		// Send our received frame to Topic for distribution to the consumer(s)
-		top.Broadcast <- frame
-
-	}
-
+func (b *broadcaster) subscribe() chan []byte {
+	ch := make(chan []byte, 16)
+	b.mu.Lock()
+	b.consumers[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
 }
 
-// This function reads from the Topic consumer and writes what it gets to the network
-func serialReaderConsumer(consumer chan interface{}, conn net.Conn, top *topic.Topic) {
-	defer conn.Close()
-	defer top.Unregister(consumer)
+func (b *broadcaster) unsubscribe(ch chan []byte) {
+	b.mu.Lock()
+	delete(b.consumers, ch)
+	b.mu.Unlock()
+	close(ch)
+}
 
-	for {
+func (b *broadcaster) send(data []byte) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.consumers {
 		select {
-		// A new message was received from this Topic consumer
-		case msg, ok := <-consumer:
-			if ok {
-				i, err := conn.Write(msg.([]byte))
-				if err != nil {
-					log.Printf("Error writing %v bytes to %v: %v\n", i, conn.RemoteAddr(), err)
-					log.Println("Client hung up.  Closing connection.")
-					conn.Close()
-					return
-				}
-			} else {
-				log.Printf("Channel closed (%v)", conn.RemoteAddr())
-				break
-			}
-		}
-	}
-}
-
-// This function reads off the network and sends everything it gets to the msg channel
-// for consumption by serialWriter()
-func serialWriterConnection(conn net.Conn, msg chan []byte) {
-	var err error
-
-	for {
-
-		frame := []byte{}
-		var first_byte byte
-
-		var frame_buffer bytes.Buffer
-
-		// Wrap a bufio.Reader around our net.Conn
-		r := bufio.NewReader(conn)
-
-		// Read our first byte, a 0xc0 and add it to the frame
-		first_byte, err = r.ReadByte()
-		if err != nil {
-			log.Printf("Error reading bytes from %v: %v", conn.RemoteAddr(), err)
-			log.Println("Client hung up.  Closing connection.")
-			conn.Close()
-			return
-		}
-
-		frame_buffer.WriteByte(first_byte)
-
-		for len(frame) <= reasonableSize {
-
-			// Read until we see a 0xc0, and store this in the frame (including that 0xc0 byte)
-			frame, err = r.ReadBytes(byte(0xc0))
-
-			if *debug {
-				fmt.Println("Byte#\tHexVal\tChar\tChar>>1\tBinary")
-				fmt.Println("-----\t------\t----\t-------\t------")
-				for k, v := range frame {
-					rs := v >> 1
-					fmt.Printf("%4d \t%#x \t%v \t%v\t%08b\n", k, v, string(v), string(rs), v)
-				}
-			}
-
-			if err != nil {
-				log.Printf("Error reading bytes from %v: %v", conn.RemoteAddr(), err)
-				log.Println("Client hung up.  Closing connection.")
-				conn.Close()
-				return
-			}
-		}
-
-		frame_buffer.Write(frame)
-
-		frame_out := frame_buffer.Bytes()
-
-		// Send the frame we just read off the network to the message buffer for eventual
-		// write to serial
-		msg <- frame_out
-
-	}
-
-}
-
-// This function reads frames off the buffered msg channel and writes them to serial
-func serialWriter(s io.ReadWriteCloser, msg chan []byte) {
-	for {
-		select {
-		case msg, ok := <-msg:
-			if ok {
-				_, err := s.Write(msg)
-				if err != nil {
-					log.Printf("Unable to write to serial port: %v\n", err)
-				}
-			} else {
-				log.Println("serialWriter message channel closed.")
-				break
-			}
+		case ch <- data:
+		default:
+			// drop frame if consumer can't keep up
 		}
 	}
 }
 
 func main() {
-
-	port := flag.String("port", "/dev/ttyUSB0", "Serial port device (default: /dev/ttyUSB0)")
-	baud := flag.Int("baud", 4800, "Baud rate for serial device (default: 4800")
-	listen = flag.String("listen", ":6700", "Address/port to listen on (defaults to 0.0.0.0:6700)")
-	debug = flag.Bool("debug", false, "Enable debugging information (default: false)")
+	portName := flag.String("port", "/dev/ttyUSB0", "serial port device")
+	baud := flag.Int("baud", 4800, "baud rate for serial device")
+	listenAddr := flag.String("listen", ":6700", "address:port to listen on")
+	debug := flag.Bool("debug", false, "enable debug output")
 	flag.Parse()
 
-	// Spin off a goroutine to watch for a SIGINT and die if we get one
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
 
-	sc := &serial.Config{Name: *port, Baud: *baud}
-
-	s, err := serial.OpenPort(sc)
+	port, err := serial.Open(*portName, &serial.Mode{BaudRate: *baud})
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("failed to open serial port", "port", *portName, "error", err)
+		os.Exit(1)
 	}
-	defer s.Close()
+	defer port.Close()
 
-	go newSerialListener(s)
+	if err := serve(ctx, *listenAddr, port, *debug); err != nil {
+		slog.Error("server error", "error", err)
+		os.Exit(1)
+	}
+}
 
-	<-sig
-	log.Println("SIGINT received.  Shutting down...")
-	os.Exit(1)
+func serve(ctx context.Context, addr string, port serial.Port, debug bool) error {
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", addr, err)
+	}
+	defer ln.Close()
+
+	slog.Info("listening for connections", "addr", addr)
+
+	bc := newBroadcaster()
+	writeCh := make(chan []byte, 15)
+
+	go readSerial(port, bc)
+	go writeSerial(port, writeCh)
+
+	go func() {
+		<-ctx.Done()
+		ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				slog.Info("shutting down")
+				return nil
+			}
+			return fmt.Errorf("accept: %w", err)
+		}
+
+		slog.Info("client connected", "remote", conn.RemoteAddr())
+
+		consumer := bc.subscribe()
+		go forwardToClient(conn, consumer, bc)
+		go forwardFromClient(conn, writeCh, debug)
+	}
+}
+
+// readSerial reads KISS frames from the serial port and broadcasts them to all clients.
+func readSerial(port serial.Port, bc *broadcaster) {
+	r := bufio.NewReader(port)
+	for {
+		var frame []byte
+		for len(frame) <= minKISSFrameSize {
+			var err error
+			frame, err = r.ReadBytes(kissDelimiter)
+			if err != nil {
+				slog.Error("serial read error", "error", err)
+				return
+			}
+		}
+		out := make([]byte, len(frame))
+		copy(out, frame)
+		bc.send(out)
+	}
+}
+
+// forwardToClient sends broadcast frames to a single TCP client.
+func forwardToClient(conn net.Conn, consumer chan []byte, bc *broadcaster) {
+	defer conn.Close()
+	defer bc.unsubscribe(consumer)
+
+	for frame := range consumer {
+		if _, err := conn.Write(frame); err != nil {
+			slog.Info("client disconnected", "remote", conn.RemoteAddr(), "error", err)
+			return
+		}
+	}
+}
+
+// forwardFromClient reads KISS frames from a TCP client and queues them for serial output.
+func forwardFromClient(conn net.Conn, writeCh chan<- []byte, debug bool) {
+	r := bufio.NewReader(conn)
+	for {
+		firstByte, err := r.ReadByte()
+		if err != nil {
+			slog.Info("client disconnected", "remote", conn.RemoteAddr(), "error", err)
+			return
+		}
+
+		var buf bytes.Buffer
+		buf.WriteByte(firstByte)
+
+		var frame []byte
+		for len(frame) <= minKISSFrameSize {
+			frame, err = r.ReadBytes(kissDelimiter)
+			if err != nil {
+				slog.Info("client disconnected", "remote", conn.RemoteAddr(), "error", err)
+				return
+			}
+
+			if debug {
+				dumpFrame(frame)
+			}
+		}
+
+		buf.Write(frame)
+		writeCh <- buf.Bytes()
+	}
+}
+
+// writeSerial drains the write channel and sends frames to the serial port.
+func writeSerial(port serial.Port, writeCh <-chan []byte) {
+	for frame := range writeCh {
+		if _, err := port.Write(frame); err != nil {
+			slog.Error("serial write error", "error", err)
+		}
+	}
+}
+
+func dumpFrame(frame []byte) {
+	fmt.Println("Byte#\tHexVal\tChar\tChar>>1\tBinary")
+	fmt.Println("-----\t------\t----\t-------\t------")
+	for i, b := range frame {
+		fmt.Printf("%4d \t%#x \t%v \t%v\t%08b\n", i, b, string(b), string(b>>1), b)
+	}
 }


### PR DESCRIPTION
Replace legacy GOPATH deps (tarm/goserial, tv42/topic) with go.bug.st/serial and an inline broadcaster. Use context for graceful shutdown, log/slog for structured logging, and idiomatic naming throughout. Add GoReleaser config and GitHub Actions workflow for automated cross-platform releases on tag push.